### PR TITLE
Changed sending input to remain compatible with ClassicUO as well

### DIFF
--- a/Source/BoxEdit/TravelEditor.cs
+++ b/Source/BoxEdit/TravelEditor.cs
@@ -736,7 +736,7 @@ namespace TheBox.Editors
 
 		private void bTest_Click(object sender, EventArgs e)
 		{
-			_ = Utility.SendToUO(String.Format("[Go {0} {1} {2}\n", CurrentLocation.X, CurrentLocation.Y, CurrentLocation.Z));
+			_ = Utility.SendToUO(String.Format("[Go {0} {1} {2}", CurrentLocation.X, CurrentLocation.Y, CurrentLocation.Z));
 		}
 
 		private void bSetCoordinates_Click(object sender, EventArgs e)

--- a/Source/Pandora/Pandora.cs
+++ b/Source/Pandora/Pandora.cs
@@ -310,11 +310,11 @@ namespace TheBox
 			{
 				if (UsePrefix)
 				{
-					success = Utility.SendToUO(String.Format("{0}{1}\r\n", Profile.General.CommandPrefix, text));
+					success = Utility.SendToUO(String.Format("{0}{1}", Profile.General.CommandPrefix, text));
 				}
 				else
 				{
-					success = Utility.SendToUO(String.Format("{0}\r\n", text));
+					success = Utility.SendToUO(String.Format("{0}", text));
 				}
 			}
 

--- a/Source/Tester/Form1.cs
+++ b/Source/Tester/Form1.cs
@@ -133,7 +133,7 @@ namespace Tester
 		private void button1_Click(object sender, EventArgs e)
 		{
 			_ = Utility.SendToUO(
-				String.Format("[go {0} {1} {2}\n", mapViewer1.Center.X, mapViewer1.Center.Y, mapViewer1.GetMapHeight()));
+				String.Format("[go {0} {1} {2}", mapViewer1.Center.X, mapViewer1.Center.Y, mapViewer1.GetMapHeight()));
 		}
 	}
 }


### PR DESCRIPTION
ClassicUO, after switching the framework that interacts with the hardware, does not accept pre-processed control characters, like new lines It is necessary to send key down/key up events instead. All the events are now sent via a single `SendInput`, instead of many `SendMessage`s